### PR TITLE
Bump elliptic from 6.5.3 to 6.5.4 (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Kotlin for FRC Changelog
 
+## [2021.2.1](https://github.com/BrenekH/kotlin-for-frc/tree/2021.2.1) (2021-02-16)
+
+**Implemented enhancements:**
+
+* Upgraded internal GradleRIO version to 2021.2.2
+
+* Added the Scheduled Tags bot to GitHub repository for an enhanced deployment workflow [\#67](https://github.com/BrenekH/kotlin-for-frc/issues/67)
+
 ## [2021.1.2](https://github.com/BrenekH/kotlin-for-frc/tree/2021.1.2) (2021-01-11)
 
 **Implemented enhancements:**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,9 @@
 # Kotlin for FRC Changelog
 
-## [2021.1.2](https://github.com/BrenekH/kotlin-for-frc/tree/2021.1.2) (2021-01-11)
+## [2021.2.1](https://github.com/BrenekH/kotlin-for-frc/tree/2021.2.1) (2021-02-16)
 
 **Implemented enhancements:**
 
-* Much smaller .vsix by removing README GIFs that link to the online version anyway
+* Upgraded internal GradleRIO version to 2021.2.2
 
-## [2021.1.1](https://github.com/BrenekH/kotlin-for-frc/tree/2021.1.1) (2021-01-06)
-
-**Implemented enhancements:**
-
-* Updated templates for the 2021 FRC season [\#60](https://github.com/BrenekH/kotlin-for-frc/issues/60)
-
-* GradleRIO version is now pulled from plugins.gradle.org, ensuring robot code is up-to-date without a new extension release [\#41](https://github.com/BrenekH/kotlin-for-frc/issues/41)
-
-* Kotlin for FRC settings are now handled through the native VSCode API instead of a custom JSON file \(`.kotlin-for-frc/kotlin-frc-preferences.json`\) [\#55](https://github.com/BrenekH/kotlin-for-frc/issues/55)
-  * New settings:
-    * `kotlinForFRC.gradleRioVersion.autoUpdate` - Whether or not to automatically update the Gradle RIO Version when the Kotlin for FRC extension is loaded.
-    * `kotlinForFRC.changelog.showOnUpdate` - Whether or not to show the changelog when Kotlin for FRC has been updated.
-    * `kotlinForFRC.simulate.javaHome` - Defines a custom JAVA_HOME for Kotlin for FRC to use when simulating FRC Kotlin code.
-
-* Added new command: `Kotlin-FRC: Simulate FRC Kotlin Code` [\#63](https://github.com/BrenekH/kotlin-for-frc/issues/63)
-  * This command just calls the `simulateJava` gradle task but is necessary because the WPILib extension also attempts to attach a debugger, but fails because there is no Java code to attach to.
-
-* Templates are now configurable [\#30](https://github.com/BrenekH/kotlin-for-frc/issues/30)
-  * Check the [wiki page](https://github.com/BrenekH/kotlin-for-frc/wiki/Custom-Templates) for more information on how to use them.
-
-**Fixed bugs:**
-
-* PIDCommand needs a wrapper in order to operate properly [\#35](https://github.com/BrenekH/kotlin-for-frc/issues/35)
-  * The 2021 templates include examples of using the Kotlin types `DoubleSupplier`, `BiConsumer` and others needed to use the inline PID commands.
+* Added the Scheduled Tags bot to GitHub repository for an enhanced deployment workflow [\#67](https://github.com/BrenekH/kotlin-for-frc/issues/67)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kotlin-for-frc",
-    "version": "2021.2.1-alpha.1",
+    "version": "2021.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1408,18 +1408,26 @@
             }
         },
         "elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
             }
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "kotlin-for-frc",
     "displayName": "Kotlin for FRC",
     "description": "Kotlin for FRC is an unofficial companion extension to the WPILib extension which adds support for Kotlin",
-    "version": "2021.2.1-alpha.1",
+    "version": "2021.2.1",
     "publisher": "Brenek",
     "engines": {
         "vscode": "^1.37.0"

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -13,58 +13,15 @@ function getWebviewContent() {
 </head>
 <body>
 <h1>Kotlin for FRC Changelog</h1>
-<h2><a href="https://github.com/BrenekH/kotlin-for-frc/tree/2021.1.2">2021.1.2</a> (2021-01-11)</h2>
+<h2><a href="https://github.com/BrenekH/kotlin-for-frc/tree/2021.2.1">2021.2.1</a> (2021-02-16)</h2>
 <p><strong>Implemented enhancements:</strong></p>
 <ul>
-	<li>Much smaller .vsix by removing README GIFs that link to the online version anyway</li>
-</ul>
-<h2><a href="https://github.com/BrenekH/kotlin-for-frc/tree/2021.1.1">2021.1.1</a> (2021-01-06)</h2>
-<p><strong>Implemented enhancements:</strong></p>
-<ul>
-	<li>
-		<p>Updated templates for the 2021 FRC season <a
-				href="https://github.com/BrenekH/kotlin-for-frc/issues/60">#60</a></p>
-	</li>
-	<li>
-		<p>GradleRIO version is now pulled from plugins.gradle.org, ensuring robot code is up-to-date without a new
-			extension release <a href="https://github.com/BrenekH/kotlin-for-frc/issues/41">#41</a></p>
-	</li>
-	<li>
-		<p>Kotlin for FRC settings are now handled through the native VSCode API instead of a custom JSON file
-			(<code>.kotlin-for-frc/kotlin-frc-preferences.json</code>) <a
-				href="https://github.com/BrenekH/kotlin-for-frc/issues/55">#55</a></p>
-	</li>
-	<li>
-		<p>New settings:</p>
-		<ul>
-			<li><code>kotlinForFRC.gradleRioVersion.autoUpdate</code> - Whether or not to automatically update the
-				Gradle RIO Version when the Kotlin for FRC extension is loaded.</li>
-			<li><code>kotlinForFRC.changelog.showOnUpdate</code> - Whether or not to show the changelog when Kotlin for
-				FRC has been updated.</li>
-			<li><code>kotlinForFRC.simulate.javaHome</code> - Defines a custom JAVA_HOME for Kotlin for FRC to use when
-				simulating FRC Kotlin code.</li>
-		</ul>
-	</li>
-	<li>
-		<p>Added new command: <code>Kotlin-FRC: Simulate FRC Kotlin Code</code> <a
-				href="https://github.com/BrenekH/kotlin-for-frc/issues/63">#63</a></p>
-	</li>
-	<li>
-		<p>This command just calls the <code>simulateJava</code> gradle task but is necessary because the WPILib
-			extension also attempts to attach a debugger, but fails because there is no Java code to attach to.</p>
-	</li>
-	<li>
-		<p>Templates are now configurable <a href="https://github.com/BrenekH/kotlin-for-frc/issues/30">#30</a></p>
-	</li>
-	<li>Check the <a href="https://github.com/BrenekH/kotlin-for-frc/wiki/Custom-Templates">wiki page</a> for more
-		information on how to use them.</li>
-</ul>
-<p><strong>Fixed bugs:</strong></p>
-<ul>
-	<li>PIDCommand needs a wrapper in order to operate properly <a
-			href="https://github.com/BrenekH/kotlin-for-frc/issues/35">#35</a></li>
-	<li>The 2021 templates include examples of using the Kotlin types <code>DoubleSupplier</code>,
-		<code>BiConsumer</code> and others needed to use the inline PID commands.</li>
+<li>
+<p>Upgraded internal GradleRIO version to 2021.2.2</p>
+</li>
+<li>
+<p>Added the Scheduled Tags bot to GitHub repository for an enhanced deployment workflow <a href="https://github.com/BrenekH/kotlin-for-frc/issues/67">#67</a></p>
+</li>
 </ul>
 </body>
 </html>`;


### PR DESCRIPTION
* Release checklist 2021.2.1

* Bump elliptic from 6.5.3 to 6.5.4

Bumps [elliptic](https://github.com/indutny/elliptic) from 6.5.3 to 6.5.4.
- [Release notes](https://github.com/indutny/elliptic/releases)
- [Commits](https://github.com/indutny/elliptic/compare/v6.5.3...v6.5.4)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: Brenek Harrison <41010693+BrenekH@users.noreply.github.com>
Co-authored-by: Brenek Harrison <brenekharrison@gmail.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>