### PR TITLE
Support VSCode Workspace Trust Feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-            "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "2021.4.1",
     "publisher": "Brenek",
     "engines": {
-        "vscode": "^1.37.0"
+        "vscode": "^1.50.0"
     },
     "categories": [
         "Other"
@@ -150,7 +150,7 @@
         "@types/glob": "^7.1.1",
         "@types/mocha": "^7.0.2",
         "@types/node": "^13.11.0",
-        "@types/vscode": "^1.37.0",
+        "@types/vscode": "^1.50.0",
         "@typescript-eslint/eslint-plugin": "^2.26.0",
         "@typescript-eslint/parser": "^2.26.0",
         "acorn": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
         "onCommand:kotlinForFRC.simulateFRCKotlinCode"
     ],
     "main": "./dist/extension",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "description": "While most of Kotlin for FRC's functionality is essentially text manipulation, it does provide a convenience feature for running the FRC simulation against Kotlin code which requires the workspace to be trusted."
+        }
+    },
     "contributes": {
         "configuration": {
             "title": "Kotlin for FRC",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
             {
                 "command": "kotlinForFRC.simulateFRCKotlinCode",
                 "title": "Simulate FRC Kotlin Code",
-                "category": "Kotlin-FRC"
+                "category": "Kotlin-FRC",
+                "when": "isWorkspaceTrusted"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -172,9 +172,7 @@
         "rimraf": "^3.0.2",
         "semver": "^7.2.2"
     },
-    "extensionDependencies": [
-        "wpilibsuite.vscode-wpilib"
-    ],
+    "extensionDependencies": [],
     "repository": {
         "type": "git",
         "url": "https://github.com/BrenekH/kotlin-for-frc.git"

--- a/package.json
+++ b/package.json
@@ -92,14 +92,13 @@
             {
                 "command": "kotlinForFRC.simulateFRCKotlinCode",
                 "title": "Simulate FRC Kotlin Code",
-                "category": "Kotlin-FRC",
-                "when": "isWorkspaceTrusted"
+                "category": "Kotlin-FRC"
             }
         ],
         "menus": {
             "explorer/context": [
                 {
-                    "when": "explorerResourceIsFolder && isWPILibProject",
+                    "when": "explorerResourceIsFolder && isKFFProject",
                     "command": "kotlinForFRC.createNew",
                     "group": "frc-kotlin"
                 }
@@ -107,26 +106,26 @@
             "commandPalette": [
                 {
                     "command": "kotlinForFRC.convertJavaProject",
-                    "when": "isWPILibProject"
+                    "when": "isKFFProject"
                 },
                 {
                     "command": "kotlinForFRC.createNew",
-                    "when": "isWPILibProject && !isWPILibProject"
+                    "when": "isKFFProject && !isKFFProject"
                 },
                 {
                     "command": "kotlinForFRC.showChangelog"
                 },
                 {
                     "command": "kotlinForFRC.resetAutoShowChangelog",
-                    "when": "isWPILibProject"
+                    "when": "isKFFProject"
                 },
                 {
                     "command": "kotlinForFRC.updateGradleRIOVersion",
-                    "when": "isWPILibProject"
+                    "when": "isKFFProject"
                 },
                 {
                     "command": "kotlinForFRC.simulateFRCKotlinCode",
-                    "when": "isWPILibProject"
+                    "when": "isWorkspaceTrusted && isKFFProject"
                 },
                 {
                     "command": "kotlinForFRC.resetGradleRIOCache"

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import * as chnglog from "../util/changelog";
 import * as customfs from "../fileManipulation/fileSystem";
 import * as kotlinExt from "../extension";
+import * as semver from "semver";
 import { createNew } from "./create_new";
 import { simulateCodeTerminalName } from "../constants";
 import { updateGradleRioVersion } from "../util/gradlerioversion";
@@ -84,6 +85,14 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 
     disposable = vscode.commands.registerCommand("kotlinForFRC.simulateFRCKotlinCode", () => {
         kotlinExt.telemetry.recordCommandRan("simulateFRCKotlinCode");
+
+        // Since we want to support older versions of VSCode, check if workspace trust is available before using it to disable simulateFRCKotlinCode
+        let isTrustedWorkspaceAvailable = semver.satisfies(vscode.version, ">=1.56.0");
+        if (isTrustedWorkspaceAvailable && !vscode.workspace.isTrusted) {
+            vscode.window.showErrorMessage("Cannot simulate code while the workspace is untrusted.");
+            return;
+        }
+
         const terminals = <vscode.Terminal[]>(<any>vscode.window).terminals;
         let searchTerminal;
         for (let t of terminals) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,9 @@ export async function activate(context: vscode.ExtensionContext) {
     // Set custom isKFFProject context
     setIsKFFProject();
 
+    // Notify user if the WPILib VSCode extension is not installed
+    alertForMissingWPILibExt();
+
     // Registering commands
     console.log("Registering commands");
     await registerCommands(context);
@@ -135,4 +138,12 @@ function setIsKFFProject() {
     customfs.exists(currentWorkspacePath + "/.wpilib/wpilib_preferences.json").then((wpilibPrefExists: Boolean) => {
         vscode.commands.executeCommand("setContext", "isKFFProject", wpilibPrefExists);
     });
+}
+
+function alertForMissingWPILibExt() {
+    const wpilibExt = vscode.extensions.getExtension("wpilibsuite.vscode-wpilib");
+
+    if (wpilibExt === undefined) {
+        vscode.window.showWarningMessage("Kotlin for FRC is meant to be a companion to the official WPILib extension, but it is not installed or you are in a restricted workspace.");
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,9 @@ export async function activate(context: vscode.ExtensionContext) {
     // Setting up current workspace
     resetWorkspaceFolderPaths();
 
+    // Set custom isKFFProject context
+    setIsKFFProject();
+
     // Registering commands
     console.log("Registering commands");
     await registerCommands(context);
@@ -126,4 +129,10 @@ export async function isGradleRioVersionUpToDate(): Promise<boolean> {
         return true;
     }
     return false;
+}
+
+function setIsKFFProject() {
+    customfs.exists(currentWorkspacePath + "/.wpilib/wpilib_preferences.json").then((wpilibPrefExists: Boolean) => {
+        vscode.commands.executeCommand("setContext", "isKFFProject", wpilibPrefExists);
+    });
 }


### PR DESCRIPTION
Adds support for [Workspace Trust](https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603).

Also upgrades minimum VSCode version to `^1.50.0` from `^1.37.0`, and removes the "official" dependency on `wpilibsuite.vscode-wpilib`.

While technically Workspace Trust is new in 1.56.0 and older versions don't support it, I don't yet want to alienate every user who isn't on the latest version so 1.50.0 and up seems like a good compromise especially when WPILib shipped 1.52.0 with their installer earlier this year.