### PR TITLE
Virtual Workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "untrustedWorkspaces": {
             "supported": "limited",
             "description": "While most of Kotlin for FRC's functionality is essentially text manipulation, it does provide a convenience feature for running the FRC simulation against Kotlin code which requires the workspace to be trusted."
-        }
+        },
+        "virtualWorkspaces": false
     },
     "contributes": {
         "configuration": {


### PR DESCRIPTION
This PR sets the `capabilities.virtualWorkspaces` key in `package.json` to false.

My original hope was to be able to support Virtual Workspaces, but I can't get VSCode Insiders to give me good information on why and where promises are being rejected. Plus the current code uses `fsPath` and `path` interchangeably(which is bad) and assumes all files are of `file` schema, which isn't necessarily true.

So for now, Virtual Workspaces won't be supported, but I would like to at some point.


Virtual Workspace links:
 * [Wiki Page](https://github.com/microsoft/vscode/wiki/Virtual-Workspaces)
 * [Tracking Issue](https://github.com/microsoft/vscode/issues/123115)