### PR TITLE
Add header to templates.ts

### DIFF
--- a/src/template/gen_templates.ts.py
+++ b/src/template/gen_templates.ts.py
@@ -13,7 +13,13 @@ def main():
         with p.open("r") as f:
             found_files[p.name.replace(".kfftemplate", "")] = f.read()
 
-    templates_ts_contents = "export class TemplateStrings {\n"
+    templates_ts_contents = """/*
+ * This file was generated using gen_templates.ts.py from the templates directory.
+ * Please do not change manually. Instead, modify the template files and then re-generate this file.
+*/
+
+export class TemplateStrings {
+"""
 
     for key in found_files:
         value: str = found_files[key]

--- a/src/template/templates.ts
+++ b/src/template/templates.ts
@@ -1,5 +1,59 @@
+/*
+ * This file was generated using gen_templates.ts.py from the templates directory.
+ * Please do not change manually. Instead, modify the template files and then re-generate this file.
+*/
+
 export class TemplateStrings {
-    buildGradle = `plugins {
+	PIDCommand = `package #{PACKAGE}
+
+import edu.wpi.first.wpilibj.controller.PIDController
+import edu.wpi.first.wpilibj2.command.PIDCommand
+import java.util.function.DoubleConsumer
+import java.util.function.DoubleSupplier
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+class #{NAME} : PIDCommand(
+        // The controller that the command will use
+        PIDController(0.0, 0.0, 0.0),
+        // This should return the measurement
+        DoubleSupplier { 0.0 },
+        // This should return the setpoint (can also be a constant)
+        DoubleSupplier { 0.0 },
+        // This uses the output
+        DoubleConsumer { output: Double -> {
+
+        }}
+    ) {
+
+    // Returns true when the command should end.
+    override fun isFinished(): Boolean {
+        return false
+    }
+}
+`
+	PIDSubsystem = `package #{PACKAGE}
+
+import edu.wpi.first.wpilibj.controller.PIDController
+import edu.wpi.first.wpilibj2.command.PIDSubsystem
+
+class #{NAME} : PIDSubsystem(
+        // The PIDController used by the subsystem
+        PIDController(0.0, 0.0, 0.0)
+    ) {
+
+    public override fun useOutput(output: Double, setpoint: Double) {
+        // Use the output here
+    }
+
+    public override fun getMeasurement(): Double {
+        // Return the process variable measurement here
+        return 0.0
+    }
+}
+`
+	buildGradle = `plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "#{GRADLE_RIO_VERSION}"
     id 'org.jetbrains.kotlin.jvm' version '1.4.21'
@@ -88,7 +142,7 @@ compileTestKotlin {
     }
 }
 `
-    command = `package #{PACKAGE}
+	command = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj2.command.CommandBase
 
@@ -115,7 +169,7 @@ class #{NAME} (): CommandBase() {
     }
 }
 `
-    commandConstants = `package frc.robot
+	commandConstants = `package frc.robot
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -128,12 +182,12 @@ class #{NAME} (): CommandBase() {
  */
 class Constants {
     companion object {
-    // Put constant values inside the companion object to make them globally accessible.
-    // ex. val motorPort: Int = 0
-}
+        // Put constant values inside the companion object to make them globally accessible.
+        // ex. val motorPort: Int = 0
+    }
 }
 `
-    commandExampleCommand = `package frc.robot.commands
+	commandExampleCommand = `package frc.robot.commands
 
 import edu.wpi.first.wpilibj2.command.CommandBase
 import frc.robot.subsystems.ExampleSubsystem
@@ -165,7 +219,7 @@ class ExampleCommand(private val subsystem: ExampleSubsystem) : CommandBase() {
     }
 }
 `
-    commandRobot = `package frc.robot
+	commandRobot = `package frc.robot
 
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj2.command.Command
@@ -264,7 +318,7 @@ class Robot : TimedRobot() {
     override fun testPeriodic() { }
 }
 `
-    emptyClass = `package #{PACKAGE}
+	emptyClass = `package #{PACKAGE}
 
 /**
  * Add your docs here.
@@ -272,7 +326,20 @@ class Robot : TimedRobot() {
 class #{NAME} {
 }
 `
-    main = `package frc.robot
+	instantCommand = `package #{PACKAGE}
+
+import edu.wpi.first.wpilibj2.command.InstantCommand
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+class #{NAME} : InstantCommand() {
+    // Called when the command is initially scheduled.
+    override fun initialize() {
+    }
+}
+`
+	main = `package frc.robot
 
 import edu.wpi.first.wpilibj.RobotBase
 
@@ -294,20 +361,7 @@ object Main {
     }
 }
 `
-    nstantCommand = `package #{PACKAGE}
-
-import edu.wpi.first.wpilibj2.command.InstantCommand
-
-// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
-// information, see:
-// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
-class #{NAME} : InstantCommand() {
-    // Called when the command is initially scheduled.
-    override fun initialize() {
-    }
-}
-`
-    oldCommand = `package #{PACKAGE}
+	oldCommand = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.command.Command
 import frc.robot.Robot
@@ -337,7 +391,7 @@ class #{NAME} : Command() {
     override fun interrupted() {}
 }
 `
-    oldCommandGroup = `package frc.robot.commands
+	oldCommandGroup = `package frc.robot.commands
 
 import edu.wpi.first.wpilibj.command.CommandGroup
 
@@ -362,7 +416,7 @@ class MyCommandGroup : CommandGroup() {
     }
 }
 `
-    oldCommandRobot = `package frc.robot
+	oldCommandRobot = `package frc.robot
 
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj.command.Command
@@ -486,7 +540,7 @@ class Robot : TimedRobot() {
     override fun testPeriodic() {}
 }
 `
-    oldInstantCommand = `package #{PACKAGE}
+	oldInstantCommand = `package #{PACKAGE}
 export class OldCommandInstantCommandTemplate {
 
 import edu.wpi.first.wpilibj.command.InstantCommand
@@ -499,7 +553,7 @@ class #{NAME} : InstantCommand() {
     override fun initialize() {}
 }
 `
-    oldOI = `package frc.robot
+	oldOI = `package frc.robot
 
 /**
  * This class is the glue that binds the controls on the physical operator
@@ -537,7 +591,7 @@ class OI {
     }
 }
 `
-    oldPIDSubsystem = `package #{PACKAGE}
+	oldPIDSubsystem = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.command.PIDSubsystem
 
@@ -563,7 +617,7 @@ class #{NAME} : PIDSubsystem("#{NAME}", 1.0, 2.0, 3.0) {
     }
 }
 `
-    oldRobotMap = `package frc.robot
+	oldRobotMap = `package frc.robot
 
 /**
  * The RobotMap is a mapping from the ports sensors and actuators are wired into
@@ -585,7 +639,7 @@ class RobotMap {
     }
 }
 `
-    oldSubsystem = `package #{PACKAGE}
+	oldSubsystem = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.command.Subsystem
 
@@ -598,7 +652,7 @@ class #{NAME} : Subsystem() {
     }
 }
 `
-    oldTimedCommand = `package #{PACKAGE}
+	oldTimedCommand = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.command.TimedCommand
 
@@ -622,7 +676,7 @@ class #{NAME}(timeout: Double) : TimedCommand(timeout) {
     override fun interrupted() {}
 }
 `
-    oldTrigger = `package #{PACKAGE}
+	oldTrigger = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.buttons.Trigger
 
@@ -635,7 +689,7 @@ class #{NAME} : Trigger() {
     }
 }
 `
-    parallelCommandGroup = `package #{PACKAGE}
+	parallelCommandGroup = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup
 
@@ -653,7 +707,7 @@ class #{NAME} : ParallelCommandGroup() {
     }
 }
 `
-    parallelDeadlineGroup = `package #{PACKAGE}
+	parallelDeadlineGroup = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj2.command.InstantCommand
 import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup
@@ -670,7 +724,7 @@ class #{NAME} : ParallelDeadlineGroup(InstantCommand()) {
     }
 }
 `
-    parallelRaceGroup = `package #{PACKAGE}
+	parallelRaceGroup = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj2.command.ParallelRaceGroup
 
@@ -688,56 +742,7 @@ class #{NAME} : ParallelRaceGroup() {
     }
 }
 `
-    PIDCommand = `package #{PACKAGE}
-
-import edu.wpi.first.wpilibj.controller.PIDController
-import edu.wpi.first.wpilibj2.command.PIDCommand
-import java.util.function.DoubleConsumer
-import java.util.function.DoubleSupplier
-
-// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
-// information, see:
-// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
-class #{NAME} : PIDCommand(
-        // The controller that the command will use
-        PIDController(0.0, 0.0, 0.0),
-        // This should return the measurement
-        DoubleSupplier { 0.0 },
-        // This should return the setpoint (can also be a constant)
-        DoubleSupplier { 0.0 },
-        // This uses the output
-        DoubleConsumer { output: Double -> {
-
-        }}
-    ) {
-
-    // Returns true when the command should end.
-    override fun isFinished(): Boolean {
-        return false
-    }
-}
-`
-    PIDSubsystem = `package #{PACKAGE}
-
-import edu.wpi.first.wpilibj.controller.PIDController
-import edu.wpi.first.wpilibj2.command.PIDSubsystem
-
-class #{NAME} : PIDSubsystem(
-        // The PIDController used by the subsystem
-        PIDController(0.0, 0.0, 0.0)
-    ) {
-
-    public override fun useOutput(output: Double, setpoint: Double) {
-        // Use the output here
-    }
-
-    public override fun getMeasurement(): Double {
-        // Return the process variable measurement here
-        return 0.0
-    }
-}
-`
-    profiledPIDCommand = `package #{PACKAGE}
+	profiledPIDCommand = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.controller.ProfiledPIDController
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile
@@ -772,7 +777,7 @@ class #{NAME} : ProfiledPIDCommand(
     }
 }
 `
-    profiledPIDSubsystem = `package #{PACKAGE}
+	profiledPIDSubsystem = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.controller.ProfiledPIDController
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile
@@ -796,7 +801,7 @@ class #{NAME} : ProfiledPIDSubsystem(
     }
 }
 `
-    robotBaseRobot = `package frc.robot
+	robotBaseRobot = `package frc.robot
 
 import edu.wpi.first.hal.HAL
 import edu.wpi.first.wpilibj.RobotBase
@@ -873,7 +878,7 @@ class Robot : RobotBase() {
     }
 }
 `
-    robotContainer = `package frc.robot
+	robotContainer = `package frc.robot
 
 import edu.wpi.first.wpilibj2.command.Command
 import frc.robot.commands.ExampleCommand
@@ -917,7 +922,7 @@ class RobotContainer {
         }
 }
 `
-    romiBuildGradle = `plugins {
+	romiBuildGradle = `plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "#{GRADLE_RIO_VERSION}"
     id 'org.jetbrains.kotlin.jvm' version '1.4.21'
@@ -980,7 +985,7 @@ compileTestKotlin {
     }
 }
 `
-    romiCommandConstants = `package frc.robot
+	romiCommandConstants = `package frc.robot
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -1014,7 +1019,7 @@ class Constants {
     }
 }
 `
-    romiCommandDrivetrainSubsystem = `package frc.robot.subsystems
+	romiCommandDrivetrainSubsystem = `package frc.robot.subsystems
 
 import edu.wpi.first.wpilibj.Encoder
 import edu.wpi.first.wpilibj.Spark
@@ -1074,7 +1079,7 @@ class RomiDrivetrain : SubsystemBase() {
     }
 }
 `
-    romiCommandExampleCommand = `package frc.robot.commands
+	romiCommandExampleCommand = `package frc.robot.commands
 
 import edu.wpi.first.wpilibj2.command.CommandBase
 import frc.robot.subsystems.RomiDrivetrain
@@ -1105,7 +1110,7 @@ class ExampleCommand(private val subsystem: RomiDrivetrain) : CommandBase() {
     }
 }
 `
-    romiCommandRobotContainer = `package frc.robot
+	romiCommandRobotContainer = `package frc.robot
 
 import edu.wpi.first.wpilibj2.command.Command
 import frc.robot.commands.ExampleCommand
@@ -1149,7 +1154,7 @@ class RobotContainer {
         }
 }
 `
-    romiTimedDrivetrain = `package frc.robot
+	romiTimedDrivetrain = `package frc.robot
 
 import edu.wpi.first.wpilibj.Encoder
 import edu.wpi.first.wpilibj.Spark
@@ -1205,7 +1210,7 @@ class RomiDrivetrain {
         get() = Math.PI * WHEEL_DIAMETER_INCH * (rightEncoderCount / COUNTS_PER_REVOLUTION)
 }
 `
-    romiTimedRobot = `package frc.robot
+	romiTimedRobot = `package frc.robot
 
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser
@@ -1313,7 +1318,7 @@ class Robot : TimedRobot() {
     override fun testPeriodic() {}
 }
 `
-    sequentialCommandGroup = `package #{PACKAGE}
+	sequentialCommandGroup = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup
 
@@ -1331,7 +1336,7 @@ class #{NAME} : SequentialCommandGroup() {
     }
 }
 `
-    subsystem = `package #{PACKAGE}
+	subsystem = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase
 
@@ -1345,7 +1350,7 @@ class #{NAME} : SubsystemBase() {
     }
 }
 `
-    timedRobot = `package frc.robot
+	timedRobot = `package frc.robot
 
 import edu.wpi.first.wpilibj.TimedRobot
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser
@@ -1451,7 +1456,7 @@ class Robot : TimedRobot() {
     override fun testPeriodic() {}
 }
 `
-    timedSkeletonRobot = `package frc.robot
+	timedSkeletonRobot = `package frc.robot
 
 import edu.wpi.first.wpilibj.TimedRobot
 
@@ -1488,7 +1493,7 @@ class Robot : TimedRobot() {
     override fun testPeriodic() {}
 }
 `
-    trapezoidProfileCommand = `package #{PACKAGE}
+	trapezoidProfileCommand = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile
 import edu.wpi.first.wpilibj2.command.TrapezoidProfileCommand
@@ -1511,7 +1516,7 @@ class #{NAME} : TrapezoidProfileCommand(
         }}
     )
 `
-    trapezoidProfileSubsystem = `package #{PACKAGE}
+	trapezoidProfileSubsystem = `package #{PACKAGE}
 
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile
 import edu.wpi.first.wpilibj2.command.TrapezoidProfileSubsystem


### PR DESCRIPTION
This PR adds a file header to `src/templates/templates.ts` that lets developers know that it should be generated with `gen_templates.ts.py` instead of modified by hand.