### PR TITLE
Add recommended extensions on conversion from Java to Kotlin

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -9,6 +9,7 @@ import { writeCommandTemplate, writeRobotBaseSkeleton, writeRomiCommand, writeRo
 import { RobotType } from "./models"
 import { createFileWithContent, determineRobotType, parseTemplate } from "./util"
 import { TemplateType } from "../template/models"
+import { ensureExtensionsRecommended } from "../util/recommendations"
 
 interface ICommandExecutor {
 	execute(cmd: string, name: string, workspaceFolder: vscode.WorkspaceFolder): void
@@ -83,6 +84,8 @@ export async function registerCommands(context: vscode.ExtensionContext, templat
 				vscode.window.showErrorMessage("Kotlin-FRC: Unknown RobotType for conversion. Cancelling...")
 				return
 		}
+
+		ensureExtensionsRecommended(workspaceDir, ["Brenek.kotlin-for-frc", "wpilibsuite.vscode-wpilib"])
 
 		vscode.window.showInformationMessage("Kotlin-FRC: Conversion complete!")
 	}))

--- a/src/util/recommendations.ts
+++ b/src/util/recommendations.ts
@@ -1,7 +1,36 @@
 import * as vscode from 'vscode';
 
-export function ensureExtensionsRecommended(extensions: string[]) {
-	console.log(extensions)
-	console.log("extensions.recommendations:", vscode.workspace.getConfiguration("extensions").get("recommendations"))
-	// vscode.workspace.getConfiguration().update("extensions.recommendations", ["wpilibsuite.vscode-wpilib"])
+/**
+ * ensureExtensionsRecommended will ensure that the provided extensions are recommended through the
+ * workspaceDir.uri/.vscode/extensions.json file.
+ *
+ * This has only been tested on a non-multi-root workspace. Support for .code-workspace files is a not
+ * implemented.
+ *
+ * @param workspaceDir The parent folder of the target .vscode/extensions.json
+ * @param extensions The extensions to make sure exist in .vscode/extensions.json
+ */
+export async function ensureExtensionsRecommended(workspaceDir: vscode.WorkspaceFolder, extensions: string[]) {
+	// TODO: Make sure this function works with .code-workspace files and multi-root workspaces
+
+	const targetURI = vscode.Uri.joinPath(workspaceDir.uri, ".vscode", "extensions.json")
+
+	let extJSON: { recommendations: string[] }
+	try {
+		const extJSONData = await vscode.workspace.fs.readFile(targetURI)
+
+		extJSON = JSON.parse(Buffer.from(extJSONData).toString("utf8")) as { recommendations: string[] }
+	} catch {
+		extJSON = { recommendations: [] }
+	}
+
+	extensions.forEach(extID => {
+		if (extJSON.recommendations.indexOf(extID) === -1) {
+			extJSON.recommendations.push(extID)
+		}
+	});
+
+	const extJSONStr = JSON.stringify(extJSON, null, 2)
+
+	await vscode.workspace.fs.writeFile(targetURI, Buffer.from(extJSONStr, 'utf-8'))
 }

--- a/src/util/recommendations.ts
+++ b/src/util/recommendations.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export function ensureExtensionsRecommended(extensions: string[]) {
+	console.log(extensions)
+	console.log("extensions.recommendations:", vscode.workspace.getConfiguration("extensions").get("recommendations"))
+	// vscode.workspace.getConfiguration().update("extensions.recommendations", ["wpilibsuite.vscode-wpilib"])
+}


### PR DESCRIPTION
Adds `Brenek.kotlin-for-frc` and `wpilibsuite.vscode-wpilib` to `.vscode/extensions.json` if they don't already exist.

This does not currently work with multi-root workspaces, which to my knowledge, aren't really a thing in FRC software development.

Closes #125 